### PR TITLE
Update install_dependencies.bat

### DIFF
--- a/install_dependencies.bat
+++ b/install_dependencies.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-call "zconfig/nsp_cleaner_options.cmd"
+call "zconfig/NSCB_options.cmd"
 set pycommand=%pycommand:"=%
 ECHO.
 ECHO Installing dependencies 


### PR DESCRIPTION
nsp_cleaner_options.cmd renamed to NSCB_options.cmd in the zconfig folder, causing install_dependencies.bat to break